### PR TITLE
Add bitwise ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -113,6 +113,13 @@ from keras.src.ops.numpy import argsort
 from keras.src.ops.numpy import array
 from keras.src.ops.numpy import average
 from keras.src.ops.numpy import bincount
+from keras.src.ops.numpy import bitwise_and
+from keras.src.ops.numpy import bitwise_invert
+from keras.src.ops.numpy import bitwise_left_shift
+from keras.src.ops.numpy import bitwise_not
+from keras.src.ops.numpy import bitwise_or
+from keras.src.ops.numpy import bitwise_right_shift
+from keras.src.ops.numpy import bitwise_xor
 from keras.src.ops.numpy import broadcast_to
 from keras.src.ops.numpy import ceil
 from keras.src.ops.numpy import clip
@@ -156,6 +163,7 @@ from keras.src.ops.numpy import isclose
 from keras.src.ops.numpy import isfinite
 from keras.src.ops.numpy import isinf
 from keras.src.ops.numpy import isnan
+from keras.src.ops.numpy import left_shift
 from keras.src.ops.numpy import less
 from keras.src.ops.numpy import less_equal
 from keras.src.ops.numpy import linspace
@@ -197,6 +205,7 @@ from keras.src.ops.numpy import real
 from keras.src.ops.numpy import reciprocal
 from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
+from keras.src.ops.numpy import right_shift
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import searchsorted

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -27,6 +27,13 @@ from keras.src.ops.numpy import argsort
 from keras.src.ops.numpy import array
 from keras.src.ops.numpy import average
 from keras.src.ops.numpy import bincount
+from keras.src.ops.numpy import bitwise_and
+from keras.src.ops.numpy import bitwise_invert
+from keras.src.ops.numpy import bitwise_left_shift
+from keras.src.ops.numpy import bitwise_not
+from keras.src.ops.numpy import bitwise_or
+from keras.src.ops.numpy import bitwise_right_shift
+from keras.src.ops.numpy import bitwise_xor
 from keras.src.ops.numpy import broadcast_to
 from keras.src.ops.numpy import ceil
 from keras.src.ops.numpy import clip
@@ -70,6 +77,7 @@ from keras.src.ops.numpy import isclose
 from keras.src.ops.numpy import isfinite
 from keras.src.ops.numpy import isinf
 from keras.src.ops.numpy import isnan
+from keras.src.ops.numpy import left_shift
 from keras.src.ops.numpy import less
 from keras.src.ops.numpy import less_equal
 from keras.src.ops.numpy import linspace
@@ -111,6 +119,7 @@ from keras.src.ops.numpy import real
 from keras.src.ops.numpy import reciprocal
 from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
+from keras.src.ops.numpy import right_shift
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import select

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -113,6 +113,13 @@ from keras.src.ops.numpy import argsort
 from keras.src.ops.numpy import array
 from keras.src.ops.numpy import average
 from keras.src.ops.numpy import bincount
+from keras.src.ops.numpy import bitwise_and
+from keras.src.ops.numpy import bitwise_invert
+from keras.src.ops.numpy import bitwise_left_shift
+from keras.src.ops.numpy import bitwise_not
+from keras.src.ops.numpy import bitwise_or
+from keras.src.ops.numpy import bitwise_right_shift
+from keras.src.ops.numpy import bitwise_xor
 from keras.src.ops.numpy import broadcast_to
 from keras.src.ops.numpy import ceil
 from keras.src.ops.numpy import clip
@@ -156,6 +163,7 @@ from keras.src.ops.numpy import isclose
 from keras.src.ops.numpy import isfinite
 from keras.src.ops.numpy import isinf
 from keras.src.ops.numpy import isnan
+from keras.src.ops.numpy import left_shift
 from keras.src.ops.numpy import less
 from keras.src.ops.numpy import less_equal
 from keras.src.ops.numpy import linspace
@@ -197,6 +205,7 @@ from keras.src.ops.numpy import real
 from keras.src.ops.numpy import reciprocal
 from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
+from keras.src.ops.numpy import right_shift
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import searchsorted

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -27,6 +27,13 @@ from keras.src.ops.numpy import argsort
 from keras.src.ops.numpy import array
 from keras.src.ops.numpy import average
 from keras.src.ops.numpy import bincount
+from keras.src.ops.numpy import bitwise_and
+from keras.src.ops.numpy import bitwise_invert
+from keras.src.ops.numpy import bitwise_left_shift
+from keras.src.ops.numpy import bitwise_not
+from keras.src.ops.numpy import bitwise_or
+from keras.src.ops.numpy import bitwise_right_shift
+from keras.src.ops.numpy import bitwise_xor
 from keras.src.ops.numpy import broadcast_to
 from keras.src.ops.numpy import ceil
 from keras.src.ops.numpy import clip
@@ -70,6 +77,7 @@ from keras.src.ops.numpy import isclose
 from keras.src.ops.numpy import isfinite
 from keras.src.ops.numpy import isinf
 from keras.src.ops.numpy import isnan
+from keras.src.ops.numpy import left_shift
 from keras.src.ops.numpy import less
 from keras.src.ops.numpy import less_equal
 from keras.src.ops.numpy import linspace
@@ -111,6 +119,7 @@ from keras.src.ops.numpy import real
 from keras.src.ops.numpy import reciprocal
 from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
+from keras.src.ops.numpy import right_shift
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import select

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -369,6 +369,53 @@ def average(x, axis=None, weights=None):
     return jnp.average(x, weights=weights, axis=axis)
 
 
+def bitwise_and(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return jnp.bitwise_and(x, y)
+
+
+def bitwise_invert(x):
+    x = convert_to_tensor(x)
+    return jnp.bitwise_invert(x)
+
+
+def bitwise_not(x):
+    return bitwise_invert(x)
+
+
+def bitwise_or(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return jnp.bitwise_or(x, y)
+
+
+def bitwise_xor(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return jnp.bitwise_xor(x, y)
+
+
+def bitwise_left_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return jnp.bitwise_left_shift(x, y)
+
+
+def left_shift(x, y):
+    return bitwise_left_shift(x, y)
+
+
+def bitwise_right_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return jnp.bitwise_right_shift(x, y)
+
+
+def right_shift(x, y):
+    return bitwise_right_shift(x, y)
+
+
 def broadcast_to(x, shape):
     x = convert_to_tensor(x)
     return jnp.broadcast_to(x, shape)
@@ -1062,8 +1109,7 @@ def divide(x1, x2):
 def divide_no_nan(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    safe_x2 = jnp.where(x2 == 0, 1, x2)
-    return jnp.where(x2 == 0, 0, jnp.divide(x1, safe_x2))
+    return jnp.where(x2 == 0, 0, jnp.divide(x1, x2))
 
 
 def true_divide(x1, x2):

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -554,7 +554,7 @@ class JAXTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = {}
+        logs = None
         self.reset_metrics()
 
         self._jax_state_synced = True

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -3,6 +3,7 @@ import functools
 import warnings
 
 import numpy as np
+import optree
 
 from keras.src import tree
 from keras.src.backend.common import KerasVariable
@@ -209,16 +210,16 @@ def associative_scan(f, elems, reverse=False, axis=0):
     # Ref: jax.lax.associative_scan
     if not callable(f):
         raise TypeError(f"`f` should be a callable. Received: f={f}")
-    elems_flat = tree.flatten(elems)
+    elems_flat, tree = optree.tree_flatten(elems)
     elems_flat = [convert_to_tensor(elem) for elem in elems_flat]
     if reverse:
         elems_flat = [np.flip(elem, (axis,)) for elem in elems_flat]
 
     def _combine(a_flat, b_flat):
-        a = tree.pack_sequence_as(elems, a_flat)
-        b = tree.pack_sequence_as(elems, b_flat)
+        a = optree.tree_unflatten(tree, a_flat)
+        b = optree.tree_unflatten(tree, b_flat)
         c = f(a, b)
-        c_flat = tree.flatten(c)
+        c_flat, _ = optree.tree_flatten(c)
         return c_flat
 
     num_elems = int(elems_flat[0].shape[axis])
@@ -312,7 +313,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
     if reverse:
         scans = [np.flip(scanned, (axis,)) for scanned in scans]
 
-    return tree.pack_sequence_as(elems, scans)
+    return optree.tree_unflatten(tree, scans)
 
 
 def scatter(indices, values, shape):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -293,6 +293,53 @@ def bincount(x, weights=None, minlength=0, sparse=False):
     return np.bincount(x, weights, minlength).astype(dtype)
 
 
+def bitwise_and(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return np.bitwise_and(x, y)
+
+
+def bitwise_invert(x):
+    x = convert_to_tensor(x)
+    return np.bitwise_not(x)
+
+
+def bitwise_not(x):
+    return bitwise_invert(x)
+
+
+def bitwise_or(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return np.bitwise_or(x, y)
+
+
+def bitwise_xor(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return np.bitwise_xor(x, y)
+
+
+def bitwise_left_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return np.left_shift(x, y)
+
+
+def left_shift(x, y):
+    return bitwise_left_shift(x, y)
+
+
+def bitwise_right_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return np.right_shift(x, y)
+
+
+def right_shift(x, y):
+    return bitwise_right_shift(x, y)
+
+
 def broadcast_to(x, shape):
     return np.broadcast_to(x, shape)
 

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -276,7 +276,7 @@ class NumpyTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = {}
+        logs = None
         self.reset_metrics()
         for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_test_batch_begin(step)

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -1,6 +1,7 @@
 import builtins
 
 import numpy as np
+import optree
 import tensorflow as tf
 from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
 
@@ -223,11 +224,7 @@ def compute_output_spec(fn, *args, **kwargs):
 
 
 def cond(pred, true_fn, false_fn):
-    if isinstance(pred, tf.Variable):
-        return tf.cond(pred, true_fn=true_fn, false_fn=false_fn)
-    return tf.__internal__.smart_cond.smart_cond(
-        pred, true_fn=true_fn, false_fn=false_fn
-    )
+    return tf.cond(pred, true_fn=true_fn, false_fn=false_fn)
 
 
 def vectorized_map(function, elements):
@@ -241,13 +238,8 @@ def map(f, xs):
         out = f(x)
         return tree.map_structure(tf.TensorSpec.from_tensor, out)
 
-    if tree.is_nested(xs):
-        input = tree.pack_sequence_as(xs, [x[0] for x in tree.flatten(xs)])
-        fn_output_signature = get_fn_output_signature(input)
-        return tf.map_fn(f, xs, fn_output_signature=fn_output_signature)
-    else:
-        fn_output_signature = get_fn_output_signature(xs[0])
-        return tf.map_fn(f, xs, fn_output_signature=fn_output_signature)
+    fn_output_signature = get_fn_output_signature(xs[0])
+    return tf.map_fn(f, xs, fn_output_signature=fn_output_signature)
 
 
 def scan(f, init, xs=None, length=None, reverse=False, unroll=1):
@@ -376,16 +368,16 @@ def associative_scan(f, elems, reverse=False, axis=0):
     # with additional checks to ensure similar behavior with jax
     if not callable(f):
         raise TypeError(f"`f` should be a callable. Received: f={f}")
-    elems_flat = tree.flatten(elems)
+    elems_flat, treespec = optree.tree_flatten(elems)
     elems_flat = [tf.convert_to_tensor(elem) for elem in elems_flat]
     if reverse:
         elems_flat = [tf.reverse(elem, [axis]) for elem in elems_flat]
 
     def _combine(a_flat, b_flat):
-        a = tree.pack_sequence_as(elems, a_flat)
-        b = tree.pack_sequence_as(elems, b_flat)
+        a = optree.tree_unflatten(treespec, a_flat)
+        b = optree.tree_unflatten(treespec, b_flat)
         c = f(a, b)
-        c_flat = tree.flatten(c)
+        c_flat, _ = optree.tree_flatten(c)
         return c_flat
 
     def _get_dim(x):
@@ -547,7 +539,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
     if reverse:
         scans = [tf.reverse(scanned, [axis]) for scanned in scans]
 
-    return tree.pack_sequence_as(elems, scans)
+    return optree.tree_unflatten(treespec, scans)
 
 
 def scatter(indices, values, shape):

--- a/keras/src/backend/tensorflow/linalg.py
+++ b/keras/src/backend/tensorflow/linalg.py
@@ -185,8 +185,6 @@ def solve_triangular(a, b, lower=False):
 
 
 def svd(x, full_matrices=True, compute_uv=True):
-    if compute_uv is False:
-        return tf.linalg.svd(x, full_matrices=full_matrices, compute_uv=False)
     s, u, v = tf.linalg.svd(
         x, full_matrices=full_matrices, compute_uv=compute_uv
     )

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -836,6 +836,68 @@ def average(x, axis=None, weights=None):
     return avg
 
 
+def bitwise_and(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = tf.cast(x, dtype)
+    y = tf.cast(y, dtype)
+    return tf.bitwise.bitwise_and(x, y)
+
+
+def bitwise_invert(x):
+    x = convert_to_tensor(x)
+    return tf.bitwise.invert(x)
+
+
+def bitwise_not(x):
+    return bitwise_invert(x)
+
+
+def bitwise_or(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = tf.cast(x, dtype)
+    y = tf.cast(y, dtype)
+    return tf.bitwise.bitwise_or(x, y)
+
+
+def bitwise_xor(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = tf.cast(x, dtype)
+    y = tf.cast(y, dtype)
+    return tf.bitwise.bitwise_xor(x, y)
+
+
+def bitwise_left_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = tf.cast(x, dtype)
+    y = tf.cast(y, dtype)
+    return tf.bitwise.left_shift(x, y)
+
+
+def left_shift(x, y):
+    return bitwise_left_shift(x, y)
+
+
+def bitwise_right_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = tf.cast(x, dtype)
+    y = tf.cast(y, dtype)
+    return tf.bitwise.right_shift(x, y)
+
+
+def right_shift(x, y):
+    return bitwise_right_shift(x, y)
+
+
 def broadcast_to(x, shape):
     return tf.broadcast_to(x, shape)
 

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -309,7 +309,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_train_function()
         callbacks.on_train_begin()
         training_logs = None
-        logs = {}
+        logs = None
         initial_epoch = self._initial_epoch or initial_epoch
         for epoch in range(initial_epoch, epochs):
             self.reset_metrics()
@@ -425,7 +425,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = {}
+        logs = None
         self.reset_metrics()
         with epoch_iterator.catch_stop_iteration():
             for step, iterator in epoch_iterator.enumerate_epoch():

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -4,6 +4,7 @@ import functools
 
 import ml_dtypes
 import numpy as np
+import optree
 import torch
 
 from keras.src import tree
@@ -436,7 +437,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
     # Ref: jax.lax.associative_scan
     if not callable(f):
         raise TypeError(f"`f` should be a callable. Received: f={f}")
-    elems_flat = tree.flatten(elems)
+    elems_flat, tree = optree.tree_flatten(elems)
     elems_flat = [convert_to_tensor(elem) for elem in elems_flat]
     if reverse:
         elems_flat = [torch.flip(elem, (axis,)) for elem in elems_flat]
@@ -445,10 +446,10 @@ def associative_scan(f, elems, reverse=False, axis=0):
         a_flat = [convert_to_tensor(a) for a in a_flat]
         b_flat = [convert_to_tensor(b) for b in b_flat]
 
-        a = tree.pack_sequence_as(elems, a_flat)
-        b = tree.pack_sequence_as(elems, b_flat)
+        a = optree.tree_unflatten(tree, a_flat)
+        b = optree.tree_unflatten(tree, b_flat)
         c = f(a, b)
-        c_flat = tree.flatten(c)
+        c_flat, _ = optree.tree_flatten(c)
         return c_flat
 
     num_elems = int(elems_flat[0].shape[axis])
@@ -483,12 +484,12 @@ def associative_scan(f, elems, reverse=False, axis=0):
         a_pad = [[0, 0] for _ in range(a.dim())]
         a_pad[axis][-1] = 1 if a.shape[axis] == b.shape[axis] else 0
         a_pad = a_pad[::-1]
-        a_pad = tree.flatten(a_pad)
+        a_pad, _ = optree.tree_flatten(a_pad)
 
         b_pad = [[0, 0] for _ in range(b.dim())]
         b_pad[axis] = [1, 0] if a.shape[axis] == b.shape[axis] else [1, 1]
         b_pad = b_pad[::-1]
-        b_pad = tree.flatten(b_pad)
+        b_pad, _ = optree.tree_flatten(b_pad)
 
         op = torch.bitwise_or if a.dtype == torch.bool else torch.add
         return op(
@@ -547,7 +548,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
     if reverse:
         scans = [torch.flip(scanned, (axis,)) for scanned in scans]
 
-    return tree.pack_sequence_as(elems, scans)
+    return optree.tree_unflatten(tree, scans)
 
 
 def scatter(indices, values, shape):

--- a/keras/src/backend/torch/linalg.py
+++ b/keras/src/backend/torch/linalg.py
@@ -68,7 +68,9 @@ def solve_triangular(a, b, lower=False):
 
 def svd(x, full_matrices=True, compute_uv=True):
     if not compute_uv:
-        return torch.linalg.svdvals(x)
+        raise NotImplementedError(
+            "`compute_uv=False` is not supported for torch backend."
+        )
     return torch.linalg.svd(x, full_matrices=full_matrices)
 
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -411,6 +411,53 @@ def bincount(x, weights=None, minlength=0, sparse=False):
     return cast(torch.bincount(x, weights, minlength), dtype)
 
 
+def bitwise_and(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return torch.bitwise_and(x, y)
+
+
+def bitwise_invert(x):
+    x = convert_to_tensor(x)
+    return torch.bitwise_not(x)
+
+
+def bitwise_not(x):
+    return bitwise_invert(x)
+
+
+def bitwise_or(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return torch.bitwise_or(x, y)
+
+
+def bitwise_xor(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return torch.bitwise_xor(x, y)
+
+
+def bitwise_left_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return torch.bitwise_left_shift(x, y)
+
+
+def left_shift(x, y):
+    return bitwise_left_shift(x, y)
+
+
+def bitwise_right_shift(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    return torch.bitwise_right_shift(x, y)
+
+
+def right_shift(x, y):
+    return bitwise_right_shift(x, y)
+
+
 def broadcast_to(x, shape):
     x = convert_to_tensor(x)
     return torch.broadcast_to(x, shape)

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -366,7 +366,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = {}
+        logs = None
         self.reset_metrics()
         for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_test_batch_begin(step)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -436,7 +436,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         ("int8", "int8_from_float32", 3),
         ("float8", "float8_from_float32", 8),
     )
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
     def test_quantize_by_setting_dtype_policy(
         self, policy, expected_num_variables
     ):
@@ -482,7 +481,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         ("float8", "float8_from_mixed_bfloat16", 8, 0),
     )
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
     def test_quantize_dtype_argument(
         self, dtype, num_trainable_weights, num_non_trainable_weights
     ):
@@ -499,7 +497,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         )
 
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
     def test_quantize_int8_when_lora_enabled(self):
         # Note that saving and loading with lora_enabled and quantized are
         # lossy, so we use a weak correctness test for model outputs (atol=0.5).
@@ -581,7 +578,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             )
 
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
     def test_quantize_float8(self):
         import ml_dtypes
 

--- a/keras/src/metrics/accuracy_metrics.py
+++ b/keras/src/metrics/accuracy_metrics.py
@@ -110,6 +110,12 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
     """
 
     def __init__(self, name="binary_accuracy", dtype=None, threshold=0.5):
+        if threshold is not None and (threshold <= 0 or threshold >= 1):
+            raise ValueError(
+                "Invalid value for argument `threshold`. "
+                "Expected a value in interval (0, 1). "
+                f"Received: threshold={threshold}"
+            )
         super().__init__(
             fn=binary_accuracy, name=name, dtype=dtype, threshold=threshold
         )

--- a/keras/src/metrics/accuracy_metrics_test.py
+++ b/keras/src/metrics/accuracy_metrics_test.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 
 from keras.src import testing
@@ -171,6 +173,18 @@ class BinaryAccuracyTest(testing.TestCase):
         # Higher threshold must result in lower measured accuracy.
         self.assertAllClose(result_1, 1.0)
         self.assertAllClose(result_2, 0.75)
+
+    def test_invalid_threshold(self):
+        self.assertRaisesRegex(
+            ValueError,
+            re.compile(r"Invalid value for argument `threshold`"),
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=-0.5),
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            re.compile(r"Invalid value for argument `threshold`"),
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=1.5),
+        )
 
 
 class CategoricalAccuracyTest(testing.TestCase):

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1,4 +1,22 @@
+"""
+scan
+scatter
+scatter_update
+slice
+slice_update
+while_loop
+stop_gradient
+shape
+cast
+convert_to_tensor
+convert_to_numpy
+cond
+is_tensor
+custom_gradient
+"""
+
 import numpy as np
+import optree
 
 from keras.src import backend
 from keras.src import tree
@@ -194,7 +212,7 @@ class AssociativeScan(Operation):
         )
 
     def compute_output_spec(self, f, elems, axis):
-        elems_flat = tree.flatten(elems)
+        elems_flat, tree_ = optree.tree_flatten(elems)
         lens = [elem.shape[axis] for elem in elems_flat]
         if len(set(lens)) != 1:
             raise ValueError(
@@ -204,8 +222,8 @@ class AssociativeScan(Operation):
                 )
             )
 
-        x = tree.pack_sequence_as(
-            elems, [slice_along_axis(x, 0, 1, axis=axis) for x in elems_flat]
+        x = optree.tree_unflatten(
+            tree_, [slice_along_axis(x, 0, 1, axis=axis) for x in elems_flat]
         )
         y_spec = backend.compute_output_spec(f, x, x)
 

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -161,42 +161,6 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(outputs["a"], xs**2)
         self.assertAllClose(outputs["b"], xs * 10)
 
-        # Test with nested structures
-        def dict_input_fn(inputs):
-            x = inputs["x"][:, 0]
-            y = inputs["y"] + 1
-            return {"x": x, "y": y}
-
-        def list_input_fn(inputs):
-            return [x**2 for x in inputs]
-
-        xs = {
-            "x": ops.convert_to_tensor(
-                np.random.rand(4, 100, 3), dtype="float32"
-            ),
-            "y": ops.convert_to_tensor(
-                np.random.randint(0, 10, size=(4, 1)), dtype="int32"
-            ),
-        }
-        xs1 = [
-            ops.convert_to_tensor(np.random.rand(4, 100, 3), dtype="float32"),
-            ops.convert_to_tensor(
-                np.random.randint(0, 10, size=(4, 1)), dtype="int32"
-            ),
-        ]
-        ys = ops.map(dict_input_fn, xs)
-        self.assertEqual(ys["x"].shape, (4, 100))
-        self.assertEqual(
-            ops.convert_to_numpy(ys["y"]).all(),
-            ops.convert_to_numpy(xs["y"] + 1).all(),
-        )
-        ys = ops.map(list_input_fn, xs1)
-        for x, y in zip(xs1, ys):
-            self.assertEqual(
-                (ops.convert_to_numpy(y)).all(),
-                (ops.convert_to_numpy(x) ** 2).all(),
-            )
-
     def test_scan(self):
         # Test cumsum
         def cumsum(carry, xs):
@@ -702,19 +666,6 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 lambda: ops.ones((3,)),
                 lambda: ops.zeros((4,)),
             )
-
-    def test_cond_raw_bool_compile(self):
-        class ExampleLayer(layers.Layer):
-            def call(self, x, training=False):
-                return ops.cond(training, lambda: x, lambda: x * 2.0)
-
-        model = models.Sequential([ExampleLayer()])
-        model.compile(
-            optimizer=optimizers.SGD(), loss=losses.MeanSquaredError()
-        )
-        x = np.ones((2, 4), dtype=np.float32)
-        y = np.zeros((2, 4), dtype=np.float32)
-        model.evaluate(x, y, batch_size=2)
 
     def test_unstack(self):
         rng = np.random.default_rng(0)

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -534,10 +534,6 @@ class LinalgOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         # High tolerance due to numerical instability
         self.assertAllClose(x_reconstructed, x, atol=1e-3)
 
-        # Test `compute_uv=False`
-        s_no_uv = linalg.svd(x, compute_uv=False)
-        self.assertAllClose(s_no_uv, s)
-
     @parameterized.named_parameters(
         ("b_rank_1", 1, None),
         ("b_rank_2", 2, None),

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1184,6 +1184,294 @@ def bincount(x, weights=None, minlength=0, sparse=False):
     )
 
 
+class BitwiseAnd(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.bitwise_and(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.bitwise_and", "keras.ops.numpy.bitwise_and"])
+def bitwise_and(x, y):
+    """Compute the bit-wise AND of two arrays element-wise.
+
+    Computes the bit-wise AND of the underlying binary representation of the
+    integers in the input arrays. This ufunc implements the C/Python operator
+    `&`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return BitwiseAnd().symbolic_call(x, y)
+    return backend.numpy.bitwise_and(x, y)
+
+
+class BitwiseInvert(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return backend.numpy.bitwise_invert(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.bitwise_invert", "keras.ops.numpy.bitwise_invert"])
+def bitwise_invert(x):
+    """Compute bit-wise inversion, or bit-wise NOT, element-wise.
+
+    Computes the bit-wise NOT of the underlying binary representation of the
+    integers in the input arrays. This ufunc implements the C/Python operator
+    `~`.
+
+    Args:
+        x: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x,)):
+        return BitwiseInvert().symbolic_call(x)
+    return backend.numpy.bitwise_invert(x)
+
+
+class BitwiseNot(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return backend.numpy.bitwise_not(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.bitwise_not", "keras.ops.numpy.bitwise_not"])
+def bitwise_not(x):
+    """Compute bit-wise inversion, or bit-wise NOT, element-wise.
+
+    Computes the bit-wise NOT of the underlying binary representation of the
+    integers in the input arrays. This ufunc implements the C/Python operator
+    `~`.
+
+    Args:
+        x: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x,)):
+        return BitwiseNot().symbolic_call(x)
+    return backend.numpy.bitwise_not(x)
+
+
+class BitwiseOr(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.bitwise_or(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.bitwise_or", "keras.ops.numpy.bitwise_or"])
+def bitwise_or(x, y):
+    """Compute the bit-wise OR of two arrays element-wise.
+
+    Computes the bit-wise OR of the underlying binary representation of the
+    integers in the input arrays. This ufunc implements the C/Python operator
+    `|`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return BitwiseOr().symbolic_call(x, y)
+    return backend.numpy.bitwise_or(x, y)
+
+
+class BitwiseXor(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.bitwise_xor(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.bitwise_xor", "keras.ops.numpy.bitwise_xor"])
+def bitwise_xor(x, y):
+    """Compute the bit-wise XOR of two arrays element-wise.
+
+    Computes the bit-wise XOR of the underlying binary representation of the
+    integers in the input arrays. This ufunc implements the C/Python operator
+    `^`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return BitwiseXor().symbolic_call(x, y)
+    return backend.numpy.bitwise_xor(x, y)
+
+
+class BitwiseLeftShift(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.bitwise_left_shift(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(
+    ["keras.ops.bitwise_left_shift", "keras.ops.numpy.bitwise_left_shift"]
+)
+def bitwise_left_shift(x, y):
+    """Shift the bits of an integer to the left.
+
+    Bits are shifted to the left by appending `y` 0s at the right of `x`.
+    Since the internal representation of numbers is in binary format, this
+    operation is equivalent to multiplying `x` by `2**y`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return BitwiseLeftShift().symbolic_call(x, y)
+    return backend.numpy.bitwise_left_shift(x, y)
+
+
+class LeftShift(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.left_shift(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.left_shift", "keras.ops.numpy.left_shift"])
+def left_shift(x, y):
+    """Shift the bits of an integer to the left.
+
+    Bits are shifted to the left by appending `y` 0s at the right of `x`.
+    Since the internal representation of numbers is in binary format, this
+    operation is equivalent to multiplying `x` by `2**y`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return LeftShift().symbolic_call(x, y)
+    return backend.numpy.left_shift(x, y)
+
+
+class BitwiseRightShift(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.bitwise_right_shift(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(
+    ["keras.ops.bitwise_right_shift", "keras.ops.numpy.bitwise_right_shift"]
+)
+def bitwise_right_shift(x, y):
+    """Shift the bits of an integer to the right.
+
+    Bits are shifted to the right `y`. Because the internal representation of
+    numbers is in binary format, this operation is equivalent to dividing `x` by
+    `2**y`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return BitwiseRightShift().symbolic_call(x, y)
+    return backend.numpy.bitwise_right_shift(x, y)
+
+
+class RightShift(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x, y):
+        return backend.numpy.right_shift(x, y)
+
+    def compute_output_spec(self, x, y):
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        return KerasTensor(x.shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.right_shift", "keras.ops.numpy.right_shift"])
+def right_shift(x, y):
+    """Shift the bits of an integer to the right.
+
+    Bits are shifted to the right `y`. Because the internal representation of
+    numbers is in binary format, this operation is equivalent to dividing `x` by
+    `2**y`.
+
+    Args:
+        x: Input integer tensor.
+        y: Input integer tensor.
+
+    Returns:
+        Result tensor.
+    """
+    if any_symbolic_tensors((x, y)):
+        return RightShift().symbolic_call(x, y)
+    return backend.numpy.right_shift(x, y)
+
+
 class BroadcastTo(Operation):
     def __init__(self, shape):
         super().__init__()

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -70,6 +70,35 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((2, None))
         self.assertEqual(knp.arctan2(x, y).shape, (2, 3))
 
+    def test_bitwise_and(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_and(x, y).shape, (None, 3))
+
+    def test_bitwise_or(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_or(x, y).shape, (None, 3))
+
+    def test_bitwise_xor(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_xor(x, y).shape, (None, 3))
+
+    def test_bitwise_left_shift(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_left_shift(x, y).shape, (None, 3))
+
+    # left_shift is same as bitwise_left_shift
+
+    def test_bitwise_right_shift(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_right_shift(x, y).shape, (None, 3))
+
+    # right_shift is same as bitwise_right_shift
+
     def test_cross(self):
         x1 = KerasTensor((2, 3, 3))
         x2 = KerasTensor((1, 3, 2))
@@ -530,6 +559,35 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor((2, 3))
             y = KerasTensor((2, 3, 4))
             knp.arctan2(x, y)
+
+    def test_bitwise_and(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_and(x, y).shape, (2, 3))
+
+    def test_bitwise_or(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_or(x, y).shape, (2, 3))
+
+    def test_bitwise_xor(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_xor(x, y).shape, (2, 3))
+
+    def test_bitwise_left_shift(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_left_shift(x, y).shape, (2, 3))
+
+    # left_shift is same as bitwise_left_shift
+
+    def test_bitwise_right_shift(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_right_shift(x, y).shape, (2, 3))
+
+    # right_shift is same as bitwise_right_shift
 
     def test_cross(self):
         x1 = KerasTensor((2, 3, 3))
@@ -1054,6 +1112,12 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
             x = KerasTensor((None, 3, 3))
             weights = KerasTensor((None, 4))
             knp.average(x, weights=weights)
+
+    def test_bitwise_invert(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.bitwise_invert(x).shape, (None, 3))
+
+    # bitwise_not is same as bitwise_invert
 
     def test_broadcast_to(self):
         x = KerasTensor((None, 3))
@@ -1611,6 +1675,12 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_average(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.average(x).shape, ())
+
+    def test_bitwise_invert(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.bitwise_invert(x).shape, (2, 3))
+
+    # bitwise_not is same as bitwise_invert
 
     def test_broadcast_to(self):
         x = KerasTensor((2, 3))
@@ -2184,6 +2254,40 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.arctan2(x, y), np.arctan2(x, y))
 
         self.assertAllClose(knp.Arctan2()(x, y), np.arctan2(x, y))
+
+    def test_bitwise_and(self):
+        x = np.array([2, 5, 255])
+        y = np.array([3, 14, 16])
+        self.assertAllClose(knp.bitwise_and(x, y), np.bitwise_and(x, y))
+        self.assertAllClose(knp.BitwiseAnd()(x, y), np.bitwise_and(x, y))
+
+    def test_bitwise_or(self):
+        x = np.array([2, 5, 255])
+        y = np.array([3, 14, 16])
+        self.assertAllClose(knp.bitwise_or(x, y), np.bitwise_or(x, y))
+        self.assertAllClose(knp.BitwiseOr()(x, y), np.bitwise_or(x, y))
+
+    def test_bitwise_xor(self):
+        x = np.array([2, 5, 255])
+        y = np.array([3, 14, 16])
+        self.assertAllClose(knp.bitwise_xor(x, y), np.bitwise_xor(x, y))
+        self.assertAllClose(knp.BitwiseXor()(x, y), np.bitwise_xor(x, y))
+
+    def test_bitwise_left_shift(self):
+        x = np.array([50, 60, 70])
+        y = np.array([1, 2, 3])
+        self.assertAllClose(knp.bitwise_left_shift(x, y), np.left_shift(x, y))
+        self.assertAllClose(knp.BitwiseLeftShift()(x, y), np.left_shift(x, y))
+
+    # left_shift is same as bitwise_left_shift
+
+    def test_bitwise_right_shift(self):
+        x = np.array([5, 6, 7])
+        y = np.array([1, 2, 3])
+        self.assertAllClose(knp.bitwise_right_shift(x, y), np.right_shift(x, y))
+        self.assertAllClose(knp.BitwiseRightShift()(x, y), np.right_shift(x, y))
+
+    # right_shift is same as bitwise_right_shift
 
     def test_cross(self):
         x1 = np.ones([2, 1, 4, 3])
@@ -3285,6 +3389,13 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )(x)
         self.assertAllClose(output, expected_output)
         self.assertSparse(output, sparse_input or sparse_arg)
+
+    def test_bitwise_invert(self):
+        x = np.array([2, 5, 255])
+        self.assertAllClose(knp.bitwise_invert(x), np.bitwise_not(x))
+        self.assertAllClose(knp.BitwiseInvert()(x), np.bitwise_not(x))
+
+    # bitwise_not is same as bitwise_invert
 
     def test_broadcast_to(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -5774,6 +5885,115 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(
             knp.Average().symbolic_call(x1, weights=x2).dtype, expected_dtype
         )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(INT_DTYPES, 2))
+    )
+    def test_bitwise_and(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.bitwise_and(x1_jax, x2_jax).dtype
+        )
+
+        self.assertDType(knp.bitwise_and(x1, x2), expected_dtype)
+        self.assertDType(knp.BitwiseAnd().symbolic_call(x1, x2), expected_dtype)
+
+    @parameterized.named_parameters(named_product(dtype=INT_DTYPES))
+    def test_bitwise_invert(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.bitwise_invert(x_jax).dtype)
+
+        self.assertDType(knp.bitwise_invert(x), expected_dtype)
+        self.assertDType(knp.BitwiseInvert().symbolic_call(x), expected_dtype)
+
+    # bitwise_not is same as bitwise_invert
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(INT_DTYPES, 2))
+    )
+    def test_bitwise_or(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.bitwise_or(x1_jax, x2_jax).dtype)
+
+        self.assertDType(knp.bitwise_or(x1, x2), expected_dtype)
+        self.assertDType(knp.BitwiseOr().symbolic_call(x1, x2), expected_dtype)
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(INT_DTYPES, 2))
+    )
+    def test_bitwise_xor(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.bitwise_xor(x1_jax, x2_jax).dtype
+        )
+
+        self.assertDType(knp.bitwise_xor(x1, x2), expected_dtype)
+        self.assertDType(knp.BitwiseXor().symbolic_call(x1, x2), expected_dtype)
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(INT_DTYPES, 2))
+    )
+    def test_bitwise_left_shift(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.bitwise_left_shift(x1_jax, x2_jax).dtype
+        )
+
+        self.assertDType(knp.bitwise_left_shift(x1, x2), expected_dtype)
+        self.assertDType(
+            knp.BitwiseLeftShift().symbolic_call(x1, x2), expected_dtype
+        )
+
+    # left_shift is same as bitwise_left_shift
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(INT_DTYPES, 2))
+    )
+    def test_bitwise_right_shift(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.bitwise_right_shift(x1_jax, x2_jax).dtype
+        )
+
+        self.assertDType(knp.bitwise_right_shift(x1, x2), expected_dtype)
+        self.assertDType(
+            knp.BitwiseRightShift().symbolic_call(x1, x2), expected_dtype
+        )
+
+    # right_shift is same as bitwise_right_shift
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_broadcast_to(self, dtype):

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -403,7 +403,7 @@ def is_remote_path(filepath):
     Returns:
         bool: True if the filepath is a recognized remote path, otherwise False
     """
-    if re.match(r"^(/cns|/cfs|/gcs|/hdfs|/readahead|.*://).*$", str(filepath)):
+    if re.match(r"^(/cns|/cfs|/gcs|/hdfs|.*://).*$", str(filepath)):
         return True
     return False
 

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -721,9 +721,6 @@ class IsRemotePathTest(test_case.TestCase):
     def test_cfs_remote_path(self):
         self.assertTrue(file_utils.is_remote_path("/cfs/some/path"))
 
-    def test_readahead_remote_path(self):
-        self.assertTrue(file_utils.is_remote_path("/readahead/some/path"))
-
     def test_non_remote_paths(self):
         self.assertFalse(file_utils.is_remote_path("/local/path/to/file.txt"))
         self.assertFalse(

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -284,7 +284,7 @@ def print_summary(
         if not sequential_like:
             fields.append(get_connections(layer))
         if show_trainable:
-            if hasattr(layer, "weights") and len(layer.weights) > 0:
+            if layer.weights:
                 fields.append(
                     bold_text("Y", color=34)
                     if layer.trainable

--- a/keras/src/utils/summary_utils_test.py
+++ b/keras/src/utils/summary_utils_test.py
@@ -4,7 +4,6 @@ from absl.testing import parameterized
 
 from keras.src import layers
 from keras.src import models
-from keras.src import ops
 from keras.src import testing
 from keras.src.utils import summary_utils
 
@@ -74,27 +73,4 @@ class SummaryUtilsTest(testing.TestCase, parameterized.TestCase):
         self.assertIn("?", summary_content)  # unbuilt_dense
         self.assertIn("Total params: 22", summary_content)
         self.assertIn("Trainable params: 22", summary_content)
-        self.assertIn("Non-trainable params: 0", summary_content)
-
-    def test_print_model_summary_op_as_layer(self):
-        inputs = layers.Input((2,))
-        x = layers.Dense(4)(inputs)
-        outputs = ops.mean(x)
-        model = models.Model(inputs, outputs)
-
-        summary_content = []
-
-        def print_to_variable(text, line_break=False):
-            summary_content.append(text)
-
-        summary_utils.print_summary(
-            model, print_fn=print_to_variable, show_trainable=True
-        )
-        summary_content = "\n".join(summary_content)
-        self.assertIn("(None, 4)", summary_content)  # dense
-        self.assertIn("Y", summary_content)  # dense
-        self.assertIn("()", summary_content)  # mean
-        self.assertIn("-", summary_content)  # mean
-        self.assertIn("Total params: 12", summary_content)
-        self.assertIn("Trainable params: 12", summary_content)
         self.assertIn("Non-trainable params: 0", summary_content)

--- a/keras/src/version.py
+++ b/keras/src/version.py
@@ -1,7 +1,7 @@
 from keras.src.api_export import keras_export
 
 # Unique source of truth for the version number.
-__version__ = "3.5.0"
+__version__ = "3.4.1"
 
 
 @keras_export("keras.version")


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/20126

I need `left_shift` and `right_shift` in some cases.
After implementing them, I realized that it might be useful to add these bitwise ops.